### PR TITLE
Simplify the LocMgr:text function

### DIFF
--- a/mods/base/Hooks/LocalizationManager.lua
+++ b/mods/base/Hooks/LocalizationManager.lua
@@ -9,29 +9,22 @@ LocalizationManager._orig_text = LocalizationManager._orig_text or LocalizationM
 function LocalizationManager:text(str, macros, ...)
 	if self._custom_localizations[str] then
 		local return_str = self._custom_localizations[str]
-
-		-- Look for macros in the old BLT format without a trailing ;
-		if type(macros) == "table" then
-			local deprecated_use = false
-			for k, v in pairs(macros) do
-				local i, j = return_str:find("$" .. k)
-				if i and return_str:byte(j + 1) ~= 59 then -- $X format, without ;
-					return_str = return_str:gsub("$" .. k, v)
-					deprecated_use = true
-				end
-			end
-			if deprecated_use then
+		local i, j = return_str:find("$([^%s;]+)")
+		if i then
+			-- If the first macro is not using a trailing semicolon, then log the string. Checking
+			-- all macros would be a performance waste.
+			if return_str:byte(j + 1) ~= 59 then
 				log("[BLT] The use of macros without a trailing semicolon is deprecated in " .. tostring(str))
 			end
-		end
 
-		-- Look for macros in the return string in the form of $X;
-		for k in return_str:gmatch("%$([^;%s]+);") do
-			local lookup = "$" .. k .. ";"
-			local replacement = type(macros) == "table" and macros[k]
-				or self._default_macros and self._default_macros[k]
-			if replacement then
-				return_str = return_str:gsub(lookup, replacement, 1, true)
+			-- Look for macros defined as either $FORMAT or $FORMAT; (i.e. make the trailing semicolon optional)
+			if type(macros) == "table" then
+				return_str = return_str:gsub("$([^%s;]+);?", macros)
+			end
+
+			-- Handle default macros with the same format rules
+			if self._default_macros ~= nil then
+				return_str = return_str:gsub("$([^;%s]+);?", self._default_macros)
 			end
 		end
 		return return_str


### PR DESCRIPTION
In my previous commit I wrongfully assumed the default macros are stored including the format characters. This was the case in PD:TH, but has been changed somewhere in the lifetime of PD2. This makes things a lot easier and cleaner. The macro id limitations remain the same.

The deprecation check still makes sense as I still believe the original choice to change the macro format in BLT strings from the vanilla game (leaving out the trailing semicolon) is a bad choice.